### PR TITLE
Add support for custom courses

### DIFF
--- a/StudyPlannerAPI/Configuration/ValidationServiceInstaller.cs
+++ b/StudyPlannerAPI/Configuration/ValidationServiceInstaller.cs
@@ -14,5 +14,8 @@ public class ValidationServiceInstaller : IServiceInstaller
         services.AddScoped<IValidator<LinkShareParams>, LinkShareParamsValidator>();
         services.AddScoped<IValidator<UniqueBlobDTO>, UniqueBlobValidator>();
         services.AddScoped<IValidator<ProgrammeMastersParams>, ProgrammeMastersParamsValidator>();
+        services.AddScoped<IValidator<CustomCourseDTO>, CustomCourseValidator>();
+        services.AddScoped<IValidator<CustomCourseMinimalDTO>, CustomCourseMinimalValidator>();
+        services.AddScoped<IValidator<SelectedCourseDTO>, SelectedCourseValidator>();
     }
 }

--- a/StudyPlannerAPI/Controllers/LinkShareController.cs
+++ b/StudyPlannerAPI/Controllers/LinkShareController.cs
@@ -16,15 +16,20 @@ public class LinkShareController : ControllerBase
     private readonly ILinkShareManager linkShareManager;
     private readonly IValidator<LinkShareParams> linkShareValidator;
     private readonly IValidator<UniqueBlobDTO> uniqueBlobValidator;
+    private readonly IValidator<SelectedCourseDTO> selectedCourseValidator;
+    private readonly IValidator<CustomCourseDTO> customCourseValidator;
     private readonly ILogger<LinkShareController> logger;
 
-    public LinkShareController(ILinkShareManager linkShareManager, ILogger<LinkShareController> logger,
-        IValidator<LinkShareParams> linkShareValidator, IValidator<UniqueBlobDTO> uniqueBlobValidator)
+    public LinkShareController(ILinkShareManager linkShareManager, IValidator<LinkShareParams> linkShareValidator,
+        IValidator<UniqueBlobDTO> uniqueBlobValidator, IValidator<CustomCourseDTO> customCourseValidator,
+        IValidator<SelectedCourseDTO> selectedCourseValidator, ILogger<LinkShareController> logger)
     {
         this.linkShareManager = linkShareManager;
-        this.logger = logger;
         this.linkShareValidator = linkShareValidator;
         this.uniqueBlobValidator = uniqueBlobValidator;
+        this.selectedCourseValidator = selectedCourseValidator;
+        this.customCourseValidator = customCourseValidator;
+        this.logger = logger;
     }
 
     [HttpPost]
@@ -32,17 +37,48 @@ public class LinkShareController : ControllerBase
     public async Task<IActionResult> GetUniqueShareLink([FromBody] LinkShareParams linkShareParams)
     {
         var validationResult = await linkShareValidator.ValidateAsync(linkShareParams);
-        if (validationResult.IsValid)
+        if (!validationResult.IsValid)
         {
-            return await this.PerformEndpointAction(async () =>
-                await linkShareManager.GetUniqueBlobFromPlan(linkShareParams.Programme, linkShareParams.Year,
-                    linkShareParams.SelectedCourses,
-                    linkShareParams.StudyPlanName ?? Constants.STUDY_PLAN_NAME_DEFAULT,
-                    linkShareParams.UniqueBlob ?? string.Empty), logger);
+            return BadRequest(validationResult.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage)));
         }
 
-        var errors = validationResult.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage));
-        return BadRequest(errors);
+        var allValid = true;
+        var errors = new List<ValidationError>();
+        foreach (var it in linkShareParams.SelectedCourses)
+        {
+            var res = await selectedCourseValidator.ValidateAsync(it);
+            if (res.IsValid)
+            {
+                continue;
+            }
+
+            allValid = false;
+            errors.AddRange(res.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage)).ToList());
+        }
+
+        foreach (var it in linkShareParams.CustomCourses)
+        {
+            var res = await customCourseValidator.ValidateAsync(it);
+            if (res.IsValid)
+            {
+                continue;
+            }
+
+            allValid = false;
+            errors.AddRange(res.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage)).ToList());
+        }
+
+        if (!allValid)
+        {
+            return BadRequest(errors);
+        }
+
+        return await this.PerformEndpointAction(async () =>
+            await linkShareManager.GetUniqueBlobFromPlan(linkShareParams.Programme, linkShareParams.Year,
+                linkShareParams.SelectedCourses,
+                linkShareParams.StudyPlanName ?? Constants.STUDY_PLAN_NAME_DEFAULT,
+                linkShareParams.UniqueBlob ?? string.Empty,
+                linkShareParams.CustomCourses), logger);
     }
 
     [HttpGet]

--- a/StudyPlannerAPI/Controllers/MasterCheckController.cs
+++ b/StudyPlannerAPI/Controllers/MasterCheckController.cs
@@ -2,6 +2,7 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using StudyPlannerAPI.Controllers.Params;
+using StudyPlannerAPI.Database.DTO;
 using StudyPlannerAPI.Error;
 using StudyPlannerAPI.Extensions;
 using StudyPlannerAPI.Model;
@@ -14,29 +15,52 @@ public class MasterCheckController : ControllerBase
 {
     private readonly ILogger<MasterCheckController> logger;
     private readonly IMasterRequirementValidator masterRequirementValidator;
-    private readonly IValidator<MasterCheckParams> validator;
+    private readonly IValidator<MasterCheckParams> masterCheckParamValidator;
+    private readonly IValidator<CustomCourseMinimalDTO> customCourseValidator;
 
     public MasterCheckController(IMasterRequirementValidator masterRequirementValidator,
-        IValidator<MasterCheckParams> validator, ILogger<MasterCheckController> logger)
+        IValidator<MasterCheckParams> masterCheckParamValidator,
+        IValidator<CustomCourseMinimalDTO> customCourseValidator,
+        ILogger<MasterCheckController> logger)
     {
         this.masterRequirementValidator = masterRequirementValidator;
-        this.validator = validator;
+        this.masterCheckParamValidator = masterCheckParamValidator;
         this.logger = logger;
+        this.customCourseValidator = customCourseValidator;
     }
 
     [HttpPost]
     [Consumes(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> CheckMasterRequirements([FromBody] MasterCheckParams masterCheckParams)
     {
-        var validationResult = await validator.ValidateAsync(masterCheckParams);
-        if (validationResult.IsValid)
+        var validationResult = await masterCheckParamValidator.ValidateAsync(masterCheckParams);
+        if (!validationResult.IsValid)
         {
-            return await this.PerformEndpointAction(
-                async () => await masterRequirementValidator.ValidateCourseSelection(masterCheckParams.Programme,
-                    masterCheckParams.Year, masterCheckParams.SelectedCourses, masterCheckParams.MasterCodes), logger);
+            return BadRequest(validationResult.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage)));
         }
 
-        var errors = validationResult.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage));
-        return BadRequest(errors);
+        var allValid = true;
+        var errors = new List<ValidationError>();
+        foreach (var it in masterCheckParams.CustomCourses)
+        {
+            var res = await customCourseValidator.ValidateAsync(it);
+            if (res.IsValid)
+            {
+                continue;
+            }
+
+            allValid = false;
+            errors.AddRange(res.Errors.Select(e => new ValidationError(e.ErrorCode, e.ErrorMessage)).ToList());
+        }
+
+        if (!allValid)
+        {
+            return BadRequest(errors);
+        }
+
+        return await this.PerformEndpointAction(
+            async () => await masterRequirementValidator.ValidateCourseSelection(masterCheckParams.Programme,
+                masterCheckParams.Year, masterCheckParams.SelectedCourses, masterCheckParams.MasterCodes,
+                masterCheckParams.CustomCourses), logger);
     }
 }

--- a/StudyPlannerAPI/Controllers/Params/LinkShareParams.cs
+++ b/StudyPlannerAPI/Controllers/Params/LinkShareParams.cs
@@ -1,4 +1,5 @@
-﻿using StudyPlannerAPI.Database.DTO;
+﻿using System.Text.Json.Serialization;
+using StudyPlannerAPI.Database.DTO;
 
 namespace StudyPlannerAPI.Controllers.Params;
 
@@ -9,4 +10,8 @@ public class LinkShareParams
     public string Year { get; set; }
     public string StudyPlanName { get; set; }
     public List<SelectedCourseDTO> SelectedCourses { get; set; } = new();
+
+    // FIXME: change magic strings to constants. Depends on PR #54
+    [JsonPropertyName("customCourses")]
+    public List<CustomCourseDTO> CustomCourses { get; set; } = new();
 }

--- a/StudyPlannerAPI/Controllers/Params/MasterCheckParams.cs
+++ b/StudyPlannerAPI/Controllers/Params/MasterCheckParams.cs
@@ -1,4 +1,6 @@
-﻿namespace StudyPlannerAPI.Controllers.Params;
+﻿using StudyPlannerAPI.Database.DTO;
+
+namespace StudyPlannerAPI.Controllers.Params;
 
 public class MasterCheckParams
 {
@@ -6,4 +8,5 @@ public class MasterCheckParams
     public string Year { get; set; }
     public List<string> MasterCodes { get; set; } = new();
     public List<string> SelectedCourses { get; set; } = new();
+    public List<CustomCourseMinimalDTO> CustomCourses { get; set; } = new();
 }

--- a/StudyPlannerAPI/Controllers/Validation/CustomCourseMinimalValidator.cs
+++ b/StudyPlannerAPI/Controllers/Validation/CustomCourseMinimalValidator.cs
@@ -1,0 +1,39 @@
+﻿using FluentValidation;
+using StudyPlannerAPI.Database.DTO;
+using StudyPlannerAPI.Error;
+using StudyPlannerAPI.Extensions;
+
+namespace StudyPlannerAPI.Controllers.Validation;
+
+public class CustomCourseMinimalValidator : AbstractValidator<CustomCourseMinimalDTO>
+{
+    public CustomCourseMinimalValidator()
+    {
+        RuleFor(c => c.course_code)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.level)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.course_code)
+            .Must(cc => cc.Length > 0)
+            .When(c => c.course_code != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c => ErrorUtil.OneChar(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.level)
+            .Must(l => l is Constants.G1_CREDITS or Constants.G2_CREDITS or Constants.A_CREDITS)
+            .When(c => c.level != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.InvalidFormat(nameof(c.level).ToCamelCase()));
+
+        RuleFor(c => c.credits)
+            .Must(cr => cr > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.credits).ToCamelCase()));
+    }
+}

--- a/StudyPlannerAPI/Controllers/Validation/CustomCourseValidator.cs
+++ b/StudyPlannerAPI/Controllers/Validation/CustomCourseValidator.cs
@@ -1,0 +1,73 @@
+﻿using FluentValidation;
+using StudyPlannerAPI.Database.DTO;
+using StudyPlannerAPI.Error;
+using StudyPlannerAPI.Extensions;
+
+namespace StudyPlannerAPI.Controllers.Validation;
+
+public class CustomCourseValidator : AbstractValidator<CustomCourseDTO>
+{
+    public CustomCourseValidator()
+    {
+        RuleFor(c => c.course_code)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.course_name)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.level)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.course_code)
+            .Must(cc => cc.Length > 0)
+            .When(c => c.course_code != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c => ErrorUtil.OneChar(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.course_name)
+            .Must(n => n.Length > 0)
+            .When(c => c.course_name != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c =>
+                $"[{c.course_code}] " + ErrorUtil.OneChar(nameof(c.course_name).ToCamelCase()));
+
+        RuleFor(c => c.level)
+            .Must(l => l is Constants.G1_CREDITS or Constants.G2_CREDITS or Constants.A_CREDITS)
+            .When(c => c.level != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.InvalidFormat(nameof(c.level).ToCamelCase()));
+
+        RuleFor(c => c.credits)
+            .Must(cr => cr > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.credits).ToCamelCase()));
+
+        RuleFor(c => c.study_year)
+            .Must(y => y > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.study_year).ToCamelCase()));
+
+        RuleFor(c => c.period_start)
+            .Must(p => p > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.period_start).ToCamelCase()));
+
+        RuleFor(c => c.period_end)
+            .Must(p => p > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.period_end).ToCamelCase()));
+
+        RuleFor(c => new[] { c.period_start, c.period_end })
+            .Must(p => p[0] <= p[1])
+            .When(c => c.period_start > 0 && c.period_end > 0)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c =>
+                $"[{c.course_code}] Param '{nameof(c.period_end).ToCamelCase()}' must be greater than or equal to param '{nameof(c.period_start).ToCamelCase()}'!");
+    }
+}

--- a/StudyPlannerAPI/Controllers/Validation/LinkShareParamsValidator.cs
+++ b/StudyPlannerAPI/Controllers/Validation/LinkShareParamsValidator.cs
@@ -28,6 +28,6 @@ public class LinkShareParamsValidator : AbstractValidator<LinkShareParams>
         RuleFor(lsp => lsp.SelectedCourses)
             .Must(courses => courses.Count > 0)
             .WithErrorCode(ErrorCodes.COUNT_LEQ_ZERO)
-            .WithMessage(ErrorUtil.LeqZero(nameof(LinkShareParams.SelectedCourses)));
+            .WithMessage(ErrorUtil.CountLeqZero(nameof(LinkShareParams.SelectedCourses)));
     }
 }

--- a/StudyPlannerAPI/Controllers/Validation/MasterCheckParamsValidator.cs
+++ b/StudyPlannerAPI/Controllers/Validation/MasterCheckParamsValidator.cs
@@ -28,6 +28,6 @@ public class MasterCheckParamsValidator : AbstractValidator<MasterCheckParams>
         RuleFor(mcp => mcp.SelectedCourses)
             .Must(courses => courses.Count > 0)
             .WithErrorCode(ErrorCodes.COUNT_LEQ_ZERO)
-            .WithMessage(ErrorUtil.LeqZero(nameof(MasterCheckParams.SelectedCourses)));
+            .WithMessage(ErrorUtil.CountLeqZero(nameof(MasterCheckParams.SelectedCourses)));
     }
 }

--- a/StudyPlannerAPI/Controllers/Validation/SelectedCourseValidator.cs
+++ b/StudyPlannerAPI/Controllers/Validation/SelectedCourseValidator.cs
@@ -1,0 +1,45 @@
+﻿using FluentValidation;
+using StudyPlannerAPI.Database.DTO;
+using StudyPlannerAPI.Error;
+using StudyPlannerAPI.Extensions;
+
+namespace StudyPlannerAPI.Controllers.Validation;
+
+public class SelectedCourseValidator : AbstractValidator<SelectedCourseDTO>
+{
+    public SelectedCourseValidator()
+    {
+        RuleFor(c => c.course_code)
+            .NotNull()
+            .WithErrorCode(ErrorCodes.PARAM_NULL)
+            .WithMessage(c => ErrorUtil.ParamNull(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.course_code)
+            .Must(cc => cc.Length > 0)
+            .When(c => c != null)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c => ErrorUtil.OneChar(nameof(c.course_code).ToCamelCase()));
+
+        RuleFor(c => c.study_year)
+            .Must(y => y > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.study_year).ToCamelCase()));
+
+        RuleFor(c => c.period_start)
+            .Must(p => p > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.period_start).ToCamelCase()));
+
+        RuleFor(c => c.period_end)
+            .Must(p => p > 0)
+            .WithErrorCode(ErrorCodes.LEQ_ZERO)
+            .WithMessage(c => $"[{c.course_code}] " + ErrorUtil.LeqZero(nameof(c.period_end).ToCamelCase()));
+
+        RuleFor(c => new[] { c.period_start, c.period_end })
+            .Must(p => p[0] <= p[1])
+            .When(c => c.period_start > 0 && c.period_end > 0)
+            .WithErrorCode(ErrorCodes.INVALID_FORMAT)
+            .WithMessage(c =>
+                $"[{c.course_code}] Param '{nameof(c.period_end).ToCamelCase()}' must be greater than or equal to param '{nameof(c.period_start).ToCamelCase()}'!");
+    }
+}

--- a/StudyPlannerAPI/Database/Columns.cs
+++ b/StudyPlannerAPI/Database/Columns.cs
@@ -9,8 +9,9 @@ public static class Columns
     public const string COURSE_CODE = "course_code";
     public const string LEVEL = "level";
     public const string CREDITS = "credits";
-    public const string COURSE_NAME_SV = "course_name_sv";
-    public const string COURSE_NAME_EN = "course_name_en";
+    public const string COURSE_NAME = "course_name";
+    public const string COURSE_NAME_SV = $"{COURSE_NAME}_sv";
+    public const string COURSE_NAME_EN = $"{COURSE_NAME}_en";
 
     // programmes
     public const string PROGRAMME_CODE = "programme_code";

--- a/StudyPlannerAPI/Database/DTO/CourseInfoDTO.cs
+++ b/StudyPlannerAPI/Database/DTO/CourseInfoDTO.cs
@@ -12,6 +12,8 @@ public class CourseInfoDTO
         Credits = credits;
     }
 
+    // FIXME: change magic strings to constants. Depends on PR #54
+
     [JsonPropertyName("courseName_en")]
     public string CourseNameEn { get; private set; }
 

--- a/StudyPlannerAPI/Database/DTO/CustomCourseDTO.cs
+++ b/StudyPlannerAPI/Database/DTO/CustomCourseDTO.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+
+#pragma warning disable IDE1006
+namespace StudyPlannerAPI.Database.DTO;
+
+public class CustomCourseDTO
+{
+    // FIXME: change magic strings to constants. Depends on PR #54
+
+    [JsonPropertyName("courseCode")]
+    public string course_code { get; set; } = string.Empty;
+
+    [JsonPropertyName("courseName")]
+    public string course_name { get; set; } = string.Empty;
+
+    [JsonPropertyName("level")]
+    public string level { get; set; } = string.Empty;
+
+    [JsonPropertyName("credits")]
+    public float credits { get; set; } = -1;
+
+    [JsonPropertyName("studyYear")]
+    public int study_year { get; set; } = -1;
+
+    [JsonPropertyName("periodStart")]
+    public int period_start { get; set; } = -1;
+
+    [JsonPropertyName("periodEnd")]
+    public int period_end { get; set; } = -1;
+}

--- a/StudyPlannerAPI/Database/DTO/CustomCourseMinimalDTO.cs
+++ b/StudyPlannerAPI/Database/DTO/CustomCourseMinimalDTO.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+#pragma warning disable IDE1006
+
+namespace StudyPlannerAPI.Database.DTO;
+
+public class CustomCourseMinimalDTO
+{
+    [JsonPropertyName("courseCode")]
+    public string course_code { get; set; } = string.Empty;
+
+    [JsonPropertyName("level")]
+    public string level { get; set; } = string.Empty;
+
+    [JsonPropertyName("credits")]
+    public float credits { get; set; } = -1;
+}

--- a/StudyPlannerAPI/Database/DTO/LinkShareDTO.cs
+++ b/StudyPlannerAPI/Database/DTO/LinkShareDTO.cs
@@ -1,4 +1,6 @@
-﻿namespace StudyPlannerAPI.Database.DTO;
+﻿using System.Text.Json.Serialization;
+
+namespace StudyPlannerAPI.Database.DTO;
 
 public class LinkShareDTO
 {
@@ -9,6 +11,9 @@ public class LinkShareDTO
 
     public bool IsReadOnly { get; set; } = false;
 
-    //public List<string> MasterCodes { get; set; } = new();
     public List<SelectedCourseDTO> SelectedCourses { get; set; } = new();
+
+    // FIXME: change magic strings to constants. Depends on PR #54
+    [JsonPropertyName("customCourses")]
+    public List<CustomCourseDTO> CustomCourses { get; set; } = new();
 }

--- a/StudyPlannerAPI/Database/Tables.cs
+++ b/StudyPlannerAPI/Database/Tables.cs
@@ -8,6 +8,7 @@ public static class Tables
 
     public const string STUDY_PLAN = "study_plan";
     public const string STUDY_PLAN_COURSE = "study_plan_course";
+    public const string STUDY_PLAN_CUSTOM_COURSE = "study_plan_custom_course";
 
     public const string PROGRAMME_MASTER_COURSE_CLASS = "programme_master_course_class";
     public const string PROGRAMME_MASTER_COURSE_YEAR = "programme_master_course_year";

--- a/StudyPlannerAPI/Error/ErrorCodes.cs
+++ b/StudyPlannerAPI/Error/ErrorCodes.cs
@@ -5,4 +5,5 @@ public static class ErrorCodes
     public const string INVALID_FORMAT = "invalid_format";
     public const string PARAM_NULL = "param_null";
     public const string COUNT_LEQ_ZERO = "count_leq_zero";
+    public const string LEQ_ZERO = "leq_zero";
 }

--- a/StudyPlannerAPI/Error/ErrorUtil.cs
+++ b/StudyPlannerAPI/Error/ErrorUtil.cs
@@ -4,21 +4,31 @@ public static class ErrorUtil
 {
     public static string InvalidFormat(string param)
     {
-        return $"Parameter {param} must be formatted correctly!";
+        return $"Parameter '{param}' must be formatted correctly!";
     }
 
     public static string ParamNull(string param)
     {
-        return $"Parameter {param} may not be null!";
+        return $"Parameter '{param}' may not be null!";
+    }
+
+    public static string CountLeqZero(string param)
+    {
+        return $"Parameter '{param}' must contain at least one element!";
     }
 
     public static string LeqZero(string param)
     {
-        return $"Parameter {param} must contain at least one element!";
+        return $"Parameter '{param}' must be a positive number!";
+    }
+
+    public static string OneChar(string param)
+    {
+        return $"Parameter '{param}' must be at least one character!";
     }
 
     public static string ConfigurationParam(string configurationParam)
     {
-        return $"Configuration parameter \"{configurationParam}\" is not defined!";
+        return $"Configuration parameter '{configurationParam}' is not defined!";
     }
 }

--- a/StudyPlannerAPI/Extensions/StringExtensions.cs
+++ b/StudyPlannerAPI/Extensions/StringExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Globalization;
+
+namespace StudyPlannerAPI.Extensions;
+
+public enum Convention
+{
+    CAMEL_CASE,
+    PASCAL_CASE,
+    SNAKE_CASE
+}
+
+public static class StringExtensions
+{
+    public static string ToCamelCase(this string value, Convention inputConvention = Convention.SNAKE_CASE)
+    {
+        return inputConvention switch
+        {
+            Convention.SNAKE_CASE => value.SnakeToCamel(),
+            Convention.PASCAL_CASE => value.PascalToCamel(),
+            Convention.CAMEL_CASE => value,
+            _ => string.Empty
+        };
+    }
+
+    private static string SnakeToCamel(this string value)
+    {
+        var words = value.Split('_');
+        if (words.Length == 0)
+        {
+            return value;
+        }
+
+        var ti = CultureInfo.CurrentCulture.TextInfo;
+        var camelCase = ti.ToLower(words[0]);
+
+        for (var i = 1; i < words.Length; i++)
+        {
+            camelCase += ti.ToTitleCase(words[i]);
+        }
+
+        return camelCase;
+    }
+
+    private static string PascalToCamel(this string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var ti = CultureInfo.CurrentUICulture.TextInfo;
+        value = ti.ToLower(value[0]) + value.Skip(1).ToString();
+        return value;
+    }
+}

--- a/StudyPlannerAPI/Model/ILinkShareManager.cs
+++ b/StudyPlannerAPI/Model/ILinkShareManager.cs
@@ -6,7 +6,8 @@ namespace StudyPlannerAPI.Model;
 public interface ILinkShareManager
 {
     Task<IActionResult> GetUniqueBlobFromPlan(string programme, string year,
-        List<SelectedCourseDTO> selectedCourses, string studyPlanName, string uniqueBlob);
+        List<SelectedCourseDTO> selectedCourses, string studyPlanName, string uniqueBlob,
+        List<CustomCourseDTO> customCourses);
 
     Task<IActionResult> GetPlanFromUniqueBlob(string uniqueBlob);
 }

--- a/StudyPlannerAPI/Model/IMasterRequirementValidator.cs
+++ b/StudyPlannerAPI/Model/IMasterRequirementValidator.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using StudyPlannerAPI.Database.DTO;
 
 namespace StudyPlannerAPI.Model;
 
 public interface IMasterRequirementValidator
 {
     Task<IActionResult> ValidateCourseSelection(string programme, string year, List<string> selectedCourses,
-        List<string> masterCodes);
+        List<string> masterCodes, List<CustomCourseMinimalDTO> customCourses);
 }

--- a/common/db/tables/study_plan_custom_course.sql
+++ b/common/db/tables/study_plan_custom_course.sql
@@ -1,0 +1,17 @@
+PRAGMA foreign_keys = off;
+
+DROP TABLE IF EXISTS study_plan_custom_course;
+CREATE TABLE study_plan_custom_course(
+    study_plan_id   TEXT,
+    course_code     TEXT NOT NULL,
+    course_name     TEXT NOT NULL,
+    level           TEXT NOT NULL,
+    credits         DOUBLE NOT NULL,
+    study_year      INTEGER NOT NULL,
+    period_start    INTEGER NOT NULL,
+    period_end      INTEGER NOT NULL,
+    PRIMARY KEY (study_plan_id, course_code),
+    FOREIGN KEY (study_plan_id) REFERENCES study_plan(study_plan_id)
+);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
This pull request adds support for custom courses, i.e courses that are not included in LTH's lists but exist in e.g Lund university's lists. This also adds validation for each type of course object such that invalid course information can not be stored in the database.

Before merging:
- [x]  Update production database with new table